### PR TITLE
feat:add file size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ dependencies {
     //  设置超时时间 (单位秒)
     Coredump.getInstance().setCoreTimeout(Coredump.DEF_TIMEOUT);
 
+    // 设置Coredump文件大小
+    Coredump.getInstance().setCoreLimit(Coredump.DEF_LIMIT);
+
     //  设置模式
     // Coredump.getInstance().setCoreMode(Coredump.MODE_PTRACE | Coredump.MODE_COPY);
     // Coredump.getInstance().setCoreMode(Coredump.MODE_PTRACE);

--- a/app/src/main/java/penguin/opencore/tester/TesterApp.java
+++ b/app/src/main/java/penguin/opencore/tester/TesterApp.java
@@ -28,7 +28,7 @@ public class TesterApp extends Application {
         Coredump.getInstance().init();
 
         Coredump.getInstance().setCoreTimeout(Coredump.DEF_TIMEOUT);
-
+        Coredump.getInstance().setCoreLimit(Coredump.DEF_LIMIT);
         //Coredump.getInstance().setCoreMode(Coredump.MODE_PTRACE | Coredump.MODE_COPY);
         //Coredump.getInstance().setCoreMode(Coredump.MODE_PTRACE);
         //Coredump.getInstance().setCoreMode(Coredump.MODE_COPY);

--- a/opencore/src/main/cpp/arm/opencore_impl.h
+++ b/opencore/src/main/cpp/arm/opencore_impl.h
@@ -89,7 +89,7 @@ public:
     void CreateCoreNoteHeader();
     void CreateCorePrStatus(pid_t pid);
     void CreateCoreAUXV(pid_t pid);
-
+    int WriteAndRecord(const void *buf, size_t size, size_t count, FILE *stream);
     // ELF Header
     void WriteCoreHeader(FILE* fp);
 

--- a/opencore/src/main/cpp/arm64/opencore_impl.h
+++ b/opencore/src/main/cpp/arm64/opencore_impl.h
@@ -87,7 +87,7 @@ public:
     void CreateCoreNoteHeader();
     void CreateCorePrStatus(pid_t pid);
     void CreateCoreAUXV(pid_t pid);
-
+    int WriteAndRecord(const void *buf, size_t size, size_t count, FILE *stream);
     // ELF Header
     void WriteCoreHeader(FILE* fp);
 

--- a/opencore/src/main/cpp/opencore.h
+++ b/opencore/src/main/cpp/opencore.h
@@ -97,6 +97,8 @@ public:
 
     static const int DEF_TIMEOUT = 30;
 
+    static const long DEF_LIMIT = -1L; //  unlimited
+
     static const int INVALID_TID = 0;
 
     static const int FILTER_NONE = 0x0;
@@ -116,6 +118,7 @@ public:
     static void setCallback(DumpCallback cb);
     static void setMode(int mode);
     static void setFlag(int flag);
+    static void setLimit(long limit);
     static void setTimeout(int sec);
     static void setFilter(int filter);
     static const char* getVersion() { return OPENCORE_VERSION; }
@@ -126,22 +129,30 @@ public:
         flag = FLAG_CORE | FLAG_TID;
         state = STATE_OFF;
         timeout = DEF_TIMEOUT;
+        file_limit = DEF_LIMIT;
         tid = INVALID_TID;
         filter = FILTER_NONE;
     }
+    long file_size = 0;
     virtual bool DoCoreDump(const char* filename) = 0;
     virtual bool NeedFilterFile(const char* filename, int offset) = 0;
     std::string GetCoreDir() { return dir; }
+    char* GetCoreFilePath() { return core_path; }
+    void SetCoreFilePath(const char* path) { strcpy(core_path, path); }
     DumpCallback GetCallback() { return cb; }
     int GetMode() { return mode; }
     int GetFlag() { return flag; }
     int GetTimeout() { return timeout; }
+    int GetFileLimit() { return file_limit; }
     int GetFilter() { return filter; }
+    void AddCoreFileSuffix(const char *suffix);
+    void RemoveCoreFileSuffix();
 private:
     void SetCoreDir(std::string d) { dir = d; }
     void SetCallback(DumpCallback c) { cb = c; }
     void SetMode(int m) { mode = m; }
     void SetFlag(int f) { flag = f; }
+    void SetLimit(long l) { file_limit = l; }
     void SetTimeout(int t) { timeout = t; }
     void SetFilter(int f) { filter = f; }
     void SetState(int s) { state = s; }
@@ -150,10 +161,12 @@ private:
 
     DumpCallback cb;
     std::string dir;
+    char core_path[256];
     int mode;
     int flag;
     int state;
     int timeout;
+    long file_limit;
     int tid;
     int filter;
 };

--- a/opencore/src/main/cpp/opencore.h
+++ b/opencore/src/main/cpp/opencore.h
@@ -137,8 +137,8 @@ public:
     virtual bool DoCoreDump(const char* filename) = 0;
     virtual bool NeedFilterFile(const char* filename, int offset) = 0;
     std::string GetCoreDir() { return dir; }
-    char* GetCoreFilePath() { return core_path; }
-    void SetCoreFilePath(const char* path) { strcpy(core_path, path); }
+    std::string GetCoreFilePath() { return core_path; }
+    void SetCoreFilePath(std::string path) { core_path = path; }
     DumpCallback GetCallback() { return cb; }
     int GetMode() { return mode; }
     int GetFlag() { return flag; }
@@ -161,7 +161,7 @@ private:
 
     DumpCallback cb;
     std::string dir;
-    char core_path[256];
+    std::string core_path;
     int mode;
     int flag;
     int state;

--- a/opencore/src/main/cpp/opencore_jni.cpp
+++ b/opencore/src/main/cpp/opencore_jni.cpp
@@ -95,6 +95,7 @@ JNIEXPORT jboolean JNICALL
 Java_penguin_opencore_sdk_Coredump_native_1doCoredump(JNIEnv *env, jobject /*thiz*/, jint tid, jstring filename)
 {
     jboolean isCopy;
+
     if (filename != NULL) {
         const char *cstr = env->GetStringUTFChars(filename, &isCopy);
         Opencore::dump(true, tid, cstr);
@@ -127,6 +128,12 @@ extern "C"
 JNIEXPORT void JNICALL
 Java_penguin_opencore_sdk_Coredump_native_1setCoreFlag(JNIEnv *env, jobject /*thiz*/, jint flag) {
     Opencore::setFlag(flag);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_penguin_opencore_sdk_Coredump_native_1setCoreLimit(JNIEnv *env, jobject /*thiz*/, jlong limit) {
+    Opencore::setLimit(limit);
 }
 
 extern "C"

--- a/opencore/src/main/java/penguin/opencore/sdk/Coredump.java
+++ b/opencore/src/main/java/penguin/opencore/sdk/Coredump.java
@@ -45,6 +45,7 @@ public class Coredump {
     public static final int MODE_MAX = MODE_COPY2;
 
     private int mFlag = FLAG_CORE | FLAG_TID;
+    private long mLimit = DEF_LIMIT;
     public static final int FLAG_CORE = 1 << 0;
     public static final int FLAG_PROCESS_COMM = 1 << 1;
     public static final int FLAG_PID = 1 << 2;
@@ -54,6 +55,8 @@ public class Coredump {
 
     private int mTimeout = DEF_TIMEOUT;
     public static final int DEF_TIMEOUT = 30;
+    // default unlimited, set to 10GB
+    public static final long DEF_LIMIT = 10L << 30;
 
     private int mFilter = FILTER_NONE;
     public static final int FILTER_NONE = 0x0;
@@ -171,6 +174,11 @@ public class Coredump {
         native_setCoreFlag(mFlag);
     }
 
+    public void setCoreLimit(long limit) {
+        mLimit = limit;
+        native_setCoreLimit(mLimit);
+    }
+
     public void setCoreTimeout(int sec) {
         mTimeout = sec;
         native_setCoreTimeout(sec);
@@ -189,6 +197,7 @@ public class Coredump {
     private native void native_setCoreDir(String dir);
     private native void native_setCoreMode(int mode);
     private native void native_setCoreFlag(int flag);
+    private native void native_setCoreLimit(long limit);
     private native void native_setCoreTimeout(int sec);
     private native void native_setCoreFilter(int filter);
 


### PR DESCRIPTION
设置core file大小限制，达到限制之后截断。
```
02-20 17:29:21.903 27410 27410 I Opencore-arm64: Coredump /storage/emulated/0/Android/data/com.example.demoapp/files/core.example.demoapp_27380_Thread-2_27409_1708421361.temp ...
02-20 17:29:21.917 27410 27410 I Opencore-arm64: WriteCoreLoadSegment Mode(4)
02-20 17:29:21.921 27410 27410 E Opencore-arm64: Core file size exceeds limit: write 4096 bytes and 0 bytes until limit, core limit 1048576, truncated
02-20 17:29:21.925 27410 27410 I Opencore-arm64: Coredump Done.
```